### PR TITLE
fix: use the same image repository to wakapi repo.

### DIFF
--- a/src/wakapi/Chart.yaml
+++ b/src/wakapi/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/wakapi/values.yaml
+++ b/src/wakapi/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: n1try/wakapi
+  repository: ghcr.io/muety/wakapi
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
Cause this error so I replace image from `n1try/wakapi` to `ghcr.io/muety/wakapi` which is defined on [source repo](https://github.com/muety/wakapi?tab=readme-ov-file#-option-3-use-docker)
```
❯ k logs -f wakapi-d7594dc85-vk78v
2024-07-29T14:48:40.278831067Z [ERROR] unexpected end of JSON input
panic: unexpected end of JSON input

goroutine 1 [running]:
github.com/emvi/logbuch.(*StandardFormatter).Pnc(0x2520100?, {0x11d5162?, 0x11d5162?}, {0x0?, 0x0?, 0x0?})
        /go/pkg/mod/github.com/emvi/logbuch@v1.2.0/standard_formatter.go:57 +0x37
github.com/emvi/logbuch.(*Logger).Fatal(0x2520100, {0x11d5162, 0x1c}, {0x0, 0x0, 0x0})
        /go/pkg/mod/github.com/emvi/logbuch@v1.2.0/logger.go:132 +0x72
github.com/emvi/logbuch.Fatal(...)
        /go/pkg/mod/github.com/emvi/logbuch@v1.2.0/funcs.go:55
github.com/muety/wakapi/config.readColors()
        /src/config/config.go:426 +0x145
github.com/muety/wakapi/config.Load({0x11c09f5, 0xa}, {0x11bcc34, 0x7})
        /src/config/config.go:469 +0x2ad
main.main()
        /src/main.go:122 +0x138
```